### PR TITLE
hammerhead: disable subsystem ramdump on userdebug builds

### DIFF
--- a/init.hammerhead.rc
+++ b/init.hammerhead.rc
@@ -272,8 +272,8 @@ on property:sys.boot_completed=1
     # enable logging of wake up reasons to kernel logs
     write /sys/module/msm_show_resume_irq/parameters/debug_mask 1
 
-on property:ro.debuggable=1
-    start ssr_ramdump
+#on property:ro.debuggable=1
+#    start ssr_ramdump
 
 service rmt_storage /system/bin/rmt_storage
     class core


### PR DESCRIPTION
* left my phone connected to cpu watching monitor while it slept for about 20 mins and it was FULL of ramdumps, this is probably killing battery life so lets kill this and let the dev enable when use is needed